### PR TITLE
feat: add support for decompressing .gz files in DnfParser

### DIFF
--- a/packageviewer/db/parsers/dnf_parser.py
+++ b/packageviewer/db/parsers/dnf_parser.py
@@ -1,3 +1,4 @@
+import gzip
 import os
 import sqlite3
 import tempfile
@@ -24,6 +25,9 @@ class DnfParser:
                     out_f.write(in_f.read())
             case ".bz2":
                 with bz2.open(filepath) as in_f, open(tmp_file_obj.name, "wb") as out_f:
+                    out_f.write(in_f.read())
+            case ".gz":
+                with gzip.open(filepath) as in_f, open(tmp_file_obj.name, "wb") as out_f:
                     out_f.write(in_f.read())
             case _:
                 raise ValueError(f"Invalid extension: {ext}")


### PR DESCRIPTION
This pull request includes changes to the `packageviewer/db/parsers/dnf_parser.py` file to add support for decompressing `.gz` files. The most important changes are:

* Added import for `gzip` module to handle `.gz` file decompression.
* Updated the `decompress` method to include a case for `.gz` files, utilizing the `gzip` module to read and write the decompressed data.